### PR TITLE
Amended issue with lambda's filter to make handling more generic.

### DIFF
--- a/workshops/ec2-spot-fleet-web-app/README.md
+++ b/workshops/ec2-spot-fleet-web-app/README.md
@@ -234,7 +234,7 @@ def handler(event, context):
   instanceAction = event['detail']['instance-action']
   try:
     ec2client = boto3.client('ec2')
-    describeTags = ec2client.describe_tags(Filters=[{'Name': 'resource-id','Values':[instanceId],'Name':'key','Values':['loadBalancerTargetGroup']}])
+    describeTags = ec2client.describe_tags(Filters=[{'Name': 'resource-id','Values':[instanceId]},{'Name':'key','Values':['loadBalancerTargetGroup']}])
   except:
     print("No action being taken. Unable to describe tags for instance id:", instanceId)
     return


### PR DESCRIPTION
*Description of changes:*

When using the lambda to handle termination notifications on accounts that have more than one TargetGroup associated, the filtering was overriding the Name/Value. This was causing the describeTags to have entries not relevant for consideration and resulted in the deregister_target call to be invoked with instance-id's that were not part of the Target group.

The impact was that when using more than one Target Group, instance removal from the target group was non-deterministic, meaning that sometimes the right group would be picked up and the state will go into 'draining', sometimes it was killed without being drained.

Can be reproduced by adding another Target-Group and EC2 Fleet associated to the Target Group, with tags associated to the instances that contain `loadBalancerTargetGroup` and the `arn` of the new target group.

As evidence, I added one extra line, just before the deregister_targets line in the lambda:

```python
    elbv2client = boto3.client('elbv2')
    print("Len of describeTags: {} , describeTags: {}".format(len(describeTags['Tags']),str(describeTags['Tags'])))
    deregisterTargets = elbv2client.deregister_targets(TargetGroupArn=describeTags['Tags'][0]['Value'],Targets=[{'Id':instanceId}])
```

And got logs on cloudwatch like the one that follows:

```
Details on describeTags: 2 : [{'Key': 'loadBalancerTargetGroup', 'ResourceId': 'i-00367e3fb0cd3d883', 'ResourceType': 'instance', 'Value': 'arn:aws:elasticloadbalancing:us-east-1:781623751140:targetgroup/TestTargetGroup/532797b2f4c0466c'}, {'Key': 'loadBalancerTargetGroup', 'ResourceId': 'i-0a4f43f3eb0d3fb31', 'ResourceType': 'instance', 'Value': 'arn:aws:elasticloadbalancing:us-east-1:781623751140:targetgroup/TestGroup-2/811721e55f5ca387'}]
Detaching instance from target:
i-0a4f43f3eb0d3fb31,arn:aws:elasticloadbalancing:us-east-1:781623751140:targetgroup/TestTargetGroup/532797b2f4c0466c,{'ResponseMetadata': {'RequestId': 'd80f61e8-2424-11e9-bfc6-fd60e3b8a6d0', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': 'd80f61e8-2424-11e9-bfc6-fd60e3b8a6d0', 'content-type': 'text/xml', 'content-length': '259', 'date': 'Wed, 30 Jan 2019 00:20:27 GMT'}, 'RetryAttempts': 0}}
```

--
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
