### PR TITLE
add ecs-spot-agent

### DIFF
--- a/ecs-spot-agent/Dockerfile
+++ b/ecs-spot-agent/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7.2-alpine
+
+LABEL maintainer "mats16 <mats.kazuki@gmail.com>"
+
+RUN pip install boto3==1.9.101 requests==2.21.0
+
+COPY ecs/ /opt/ecs/
+
+ENV CHECK_INTERVAL=5
+
+CMD ["python", "-u", "/opt/ecs/check_termination.py"]

--- a/ecs-spot-agent/README.md
+++ b/ecs-spot-agent/README.md
@@ -1,0 +1,14 @@
+# ecs-spot-agent
+
+If you want to use [EC2 Spot Instances](https://aws.amazon.com/ec2/spot/) with [ECS](https://aws.amazon.com/ecs/), you need to care for termination-time.
+ecs-spot-agent can check termination-time and deregister ECS instance from ECS Cluster.
+
+## Requirement
+
+LaunchType: EC2
+NetworkMode: host
+
+## How to Use
+
+If you use ecs-spot-agent quickly, please use [CloudFormation Template](https://github.com/mats16/ec2-spot-labs/tree/master/ecs-spot-agent/ecs-spot-agent.yaml).
+You only need to choose a target ECS cluster.

--- a/ecs-spot-agent/ecs-spot-agent.yaml
+++ b/ecs-spot-agent/ecs-spot-agent.yaml
@@ -1,0 +1,88 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: 'Spot Instances Auto-Deregister from ECS Cluster'
+
+Parameters:
+
+  ecsClusterName:
+    Type: String
+    Default: default
+    Description: Target ECS Cluster Name.
+
+  ecsSpotAgentImage:
+    Type: String
+    Default: mats16/ecs-spot-agent:latest
+    Description: If you need to use other image, please change this parameter.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      -
+        Label:
+          default: "ECS Configuration"
+        Parameters:
+          - ecsClusterName
+          - ecsSpotAgentImage
+
+Resources:
+
+  LogGroup: 
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${AWS::StackName}"
+      RetentionInDays: 7
+
+  ecsTaskRole:
+    Type: "AWS::IAM::Role"
+    Properties: 
+      AssumeRolePolicyDocument: 
+        Version: "2012-10-17"
+        Statement: 
+          - 
+            Effect: "Allow"
+            Principal: 
+              Service: 
+                - "ecs-tasks.amazonaws.com"
+            Action: 
+              - "sts:AssumeRole"
+      Path: "/"
+      Policies: 
+        - 
+          PolicyName: "DeregisterContainerInstance"
+          PolicyDocument: 
+            Version: "2012-10-17"
+            Statement: 
+              - 
+                Effect: "Allow"
+                Action: "ecs:DeregisterContainerInstance"
+                Resource: arn:aws:ecs:*:*:cluster/*"
+
+  ecsTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub ${AWS::StackName}
+      TaskRoleArn: !Ref "ecsTaskRole"
+      RequiresCompatibilities: ["EC2"]
+      NetworkMode: "host"
+      ContainerDefinitions: 
+        -
+          Name: "ecs-spot-agent"
+          Image: !Ref "ecsSpotAgentImage"
+          Cpu: "10"
+          Memory: "30"
+          Essential: "true"
+          LogConfiguration:
+            LogDriver: "awslogs"
+            Options:
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-group: !Ref "LogGroup"
+              awslogs-stream-prefix: !Ref "ecsClusterName"
+
+  ecsService: 
+    Type: AWS::ECS::Service
+    Properties: 
+      Cluster: !Ref ecsClusterName
+      LaunchType: "EC2"
+      SchedulingStrategy: "DAEMON"
+      TaskDefinition: !Ref ecsTaskDefinition
+

--- a/ecs-spot-agent/ecs/check_termination.py
+++ b/ecs-spot-agent/ecs/check_termination.py
@@ -1,0 +1,55 @@
+#!/usr/local/bin/python -u
+
+import os
+import boto3
+import requests
+import traceback
+from time import sleep
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(name)s %(levelname)s %(message)s')
+
+check_interval = int(os.environ.get('CHECK_INTERVAL'))
+
+class ECS():
+    def __init__(self, region):
+        self.client = boto3.client('ecs', region_name=region)
+    def deregister(self, cluster, instance):
+        res = client.deregister_container_instance(
+            cluster=cluster,
+            containerInstance=instance,
+            force=True
+        )
+
+
+def get_region():
+    logger.info('Check region from ec2 meta-data')
+    availability_zone = requests.get('http://169.254.169.254/latest/meta-data/placement/availability-zone').text
+    return availability_zone[0:-1]
+
+def get_metadata():
+    logger.info('Check ecs metadata from ecs-agent')
+    res = requests.get('http://127.0.0.1:51678/v1/metadata')
+    metadata = res.json()
+    return metadata
+
+
+if __name__ == '__main__':
+    region = get_region()
+    metadata = get_metadata()
+    while True:
+        try:
+            res = requests.get('http://169.254.169.254/latest/meta-data/spot/termination-time')
+            if res.status_code == 404:
+                sleep(check_interval)
+                continue
+            elif res.status_code == 200:
+                logger.warn('Deregister this instance from the cluster')
+                ecs = ECS(region)
+                ecs.deregister(metadata['Cluster'], metadata['ContainerInstanceArn'])
+            else:
+                raise Exception
+        except Exception as e:
+            break
+            traceback.print_exc()


### PR DESCRIPTION
*Issue #, if available:*

nothing

*Description of changes:*

Many users using ECS with EC2 spot instances must handles spot termination, so I think that a template is needed.
This tool is an alternative for [ecs-ec2-spot-auto-deregister](https://github.com/awslabs/ec2-spot-labs/tree/master/ecs-ec2-spot-auto-deregister).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
