### PR TITLE
Deploy interrupt handler in kube-system namespace

### DIFF
--- a/ec2-spot-eks-solution/spot-termination-handler/deploy-k8-pod/spot-interrupt-handler.yaml
+++ b/ec2-spot-eks-solution/spot-termination-handler/deploy-k8-pod/spot-interrupt-handler.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: spot-interrupt-handler
-  namespace: default
+  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -32,16 +32,17 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: spot-interrupt-handler
+  namespace: kube-system
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: spot-interrupt-handler
-  namespace: default
+  namespace: kube-system
 subjects:
 - kind: ServiceAccount
   name: spot-interrupt-handler
-  namespace: default
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: spot-interrupt-handler
@@ -52,7 +53,7 @@ apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: spot-interrupt-handler
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
*Description of changes:*

I believe the interrupt handler should be deployed in the kube-system namespace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
