### PR TITLE
Change deprecated service-role "AmazonEC2SpotFleetRole"

### DIFF
--- a/ecs-ec2-spot-fleet/ecs-ec2-spot-fleet.yaml
+++ b/ecs-ec2-spot-fleet/ecs-ec2-spot-fleet.yaml
@@ -559,7 +559,7 @@ Resources:
             - spotfleet.amazonaws.com
         Version: 2012-10-17
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole
+      - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
       Path: /
     Type: AWS::IAM::Role
   vpc:


### PR DESCRIPTION
*Issue #, if available: nope*

*Description of changes:*

Change deprecated service-role "AmazonEC2SpotFleetRole" to "AmazonEC2SpotFleetTaggingRole" 
reference : https://forums.aws.amazon.com/thread.jspa?threadID=313873

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
