### PR TITLE
Adding EMR Spot example

### DIFF
--- a/ec2-spot-emr/emr-spot/Dockerfile
+++ b/ec2-spot-emr/emr-spot/Dockerfile
@@ -1,0 +1,5 @@
+FROM maven:3.6.3-jdk-8
+
+COPY . /app/
+
+WORKDIR /app/

--- a/ec2-spot-emr/emr-spot/README.md
+++ b/ec2-spot-emr/emr-spot/README.md
@@ -1,0 +1,29 @@
+# Running EMR using AWS Java v2 SDK
+## Setting up default roles
+```sh
+aws emr create-default-roles
+```
+
+## Build the docker image
+```sh
+docker build -t emr-spot-example .
+```
+
+## Run the application
+```sh
+docker build -t emr-spot-example .
+docker run --rm -it \
+       -e AWS_ACCESS_KEY_ID="" \
+       -e AWS_SECRET_ACCESS_KEY="" \
+       -e AWS_REGION="" \
+       -e EC2_KEY_NAME="" \
+       -e EC2_SUBNETS_IDs="" \ # comma-separated values
+       -v $(pwd)/.m2:/root/.m2 \
+       -v $(pwd):/app \
+       emr-spot-example bash
+```
+
+Once inside the container, run:
+```sh
+./run_example.sh
+```

--- a/ec2-spot-emr/emr-spot/pom.xml
+++ b/ec2-spot-emr/emr-spot/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>aws.example.emr</groupId>
+  <artifactId>aws-emr-examples</artifactId>
+  <version>1.0.0</version>
+  
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <java.version>1.8</java.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+    <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>1.11.720</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
+<dependencies>
+  <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.11</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>emr</artifactId>
+    <version>2.5.10</version>
+  </dependency>
+</dependencies>
+</project>
+

--- a/ec2-spot-emr/emr-spot/run_example.sh
+++ b/ec2-spot-emr/emr-spot/run_example.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mvn exec:java -Dexec.mainClass="aws.example.emr.CreateEmrFleet" -Dexec.cleanupDaemonThreads=false

--- a/ec2-spot-emr/emr-spot/src/main/java/aws/example/emr/CreateEmrFleet.java
+++ b/ec2-spot-emr/emr-spot/src/main/java/aws/example/emr/CreateEmrFleet.java
@@ -1,0 +1,165 @@
+//snippet-sourcedescription:[CreateEmrFleet.java demonstrates how to create a cluster using instance fleet with spot instances]
+//snippet-keyword:[Java]
+//snippet-sourcesyntax:[java]
+//snippet-keyword:[Code Sample]
+//snippet-keyword:[Amazon EMR]
+//snippet-keyword:[Spot Instances]
+//snippet-service:[emr]
+//snippet-sourcetype:[full-example]
+//snippet-sourcedate:[2020-02-21]
+//snippet-sourceauthor:[valdesis AWS]
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */ 
+package aws.example.emr;
+
+
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.emr.EmrClient;
+import software.amazon.awssdk.services.emr.model.*;
+
+import java.util.Arrays;
+
+/**
+ * CreateEmrFleet
+ * -------------------------------------
+ * 
+ */
+public class CreateEmrFleet {
+
+    public static void main(String[] args) throws Exception {
+
+        // Instance Types
+        // M Family
+        InstanceTypeConfig m3xLarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("m3.xlarge")
+                                                 .weightedCapacity(1)
+                                                 .build();
+        InstanceTypeConfig m4xLarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("m4.xlarge")
+                                                 .weightedCapacity(1)
+                                                 .build();
+        InstanceTypeConfig m5xLarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("m5.xlarge")
+                                                 .weightedCapacity(1)
+                                                 .build();
+        // R Family
+        InstanceTypeConfig r5xlarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("r5.xlarge")
+                                                 .weightedCapacity(2)
+                                                 .build();
+        InstanceTypeConfig r4xlarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("r4.xlarge")
+                                                 .weightedCapacity(2)
+                                                 .build();
+        InstanceTypeConfig r3xlarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("r3.xlarge")
+                                                 .weightedCapacity(2)
+                                                 .build();
+        // C Family
+        InstanceTypeConfig c32xlarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("c3.2xlarge")
+                                                 .weightedCapacity(4)
+                                                 .build();
+        InstanceTypeConfig c42xlarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("c4.2xlarge")
+                                                 .weightedCapacity(4)
+                                                 .build();
+        InstanceTypeConfig c52xlarge =  InstanceTypeConfig.builder()
+                                                 .bidPriceAsPercentageOfOnDemandPrice(100.0)
+                                                 .instanceType("c5.2xlarge")
+                                                 .weightedCapacity(4)
+                                                 .build();
+
+        // Master
+        InstanceFleetConfig masterFleet = InstanceFleetConfig.builder()
+                                                .name("master-fleet")
+                                                .instanceFleetType(InstanceFleetType.MASTER)
+                                                .instanceTypeConfigs(Arrays.asList(
+                                                  m3xLarge,
+                                                  m4xLarge,
+                                                  m5xLarge
+                                                ))
+                                                .targetOnDemandCapacity(1)
+                                                .build();
+        // Core
+        InstanceFleetConfig coreFleet = InstanceFleetConfig.builder()
+                                                .name("core-fleet")
+                                                .instanceFleetType(InstanceFleetType.CORE)
+                                                .instanceTypeConfigs(Arrays.asList(
+                                                  m3xLarge,
+                                                  m4xLarge,
+                                                  r4xlarge,
+                                                  r3xlarge,
+                                                  c32xlarge
+                                                ))
+                                                .targetOnDemandCapacity(20)
+                                                .targetSpotCapacity(10)
+                                                .build();
+        // Task
+        InstanceFleetConfig taskFleet = InstanceFleetConfig.builder()
+                                                .name("task-fleet")
+                                                .instanceFleetType(InstanceFleetType.TASK)
+                                                .instanceTypeConfigs(Arrays.asList(
+                                                  m4xLarge,
+                                                  r5xlarge,
+                                                  r4xlarge,
+                                                  c32xlarge,
+                                                  c42xlarge
+                                                ))
+                                                .targetOnDemandCapacity(8)
+                                                .targetSpotCapacity(40)
+                                                .build();
+
+        JobFlowInstancesConfig flowInstancesConfig = JobFlowInstancesConfig.builder()
+                                                      .ec2KeyName(System.getenv("EC2_KEY_NAME"))
+                                                      .keepJobFlowAliveWhenNoSteps(true)
+                                                      .instanceFleets(Arrays.asList(
+                                                        masterFleet,
+                                                        coreFleet,
+                                                        taskFleet
+                                                      ))
+                                                      .ec2SubnetIds(
+                                                        System.getenv("EC2_SUBNETS_IDs").split(",")
+                                                      )
+                                                      .build();
+
+
+        RunJobFlowRequest flowRequest = RunJobFlowRequest.builder()
+                                                    .name("emr-spot-example")
+                                                    .instances(flowInstancesConfig)
+                                                    .serviceRole("EMR_DefaultRole")
+                                                    .jobFlowRole("EMR_EC2_DefaultRole")
+                                                    .visibleToAllUsers(true)
+                                                    .applications(java.util.Arrays.asList(
+                                                      Application.builder().name("Spark").build()
+                                                    ))
+                                                    .releaseLabel("emr-5.29.0")
+                                                    .build();
+
+        EmrClient emr = EmrClient.builder().build();
+        RunJobFlowResponse response = emr.runJobFlow(flowRequest);
+        System.out.println(response.toString());
+        
+    }
+}


### PR DESCRIPTION
Use InstanceFleet and Spot instances

Description of changes:
- Create a cluster to run a JobFlow
- Use InstanceFleets with Spot Instances
- Weighted capacity for instances on Core and Task nodes
- Parameterised configuration using environment variables 

Signed-off-by: Luis Valdes <valdesis@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
