### PR TITLE
Changing print statement to use built-in function and spelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python3"
+}

--- a/aws-compute-optimizer/aws-compute-optimizer.yaml
+++ b/aws-compute-optimizer/aws-compute-optimizer.yaml
@@ -113,7 +113,7 @@ Parameters:
     Type: String
   minSize:
     Default: 5
-    Description: Mininum capacity
+    Description: Minimum capacity
     Type: Number
 Resources:
   attachGateway:

--- a/builder-sessions/ec2-asg-with-lt/README.md
+++ b/builder-sessions/ec2-asg-with-lt/README.md
@@ -1,4 +1,4 @@
-**_Pre-requesites: Amazon Web Services (AWS) developer account to launch EC2 instances. AWS CLI installed in terminal and configured with credentials to talk to AWS. All steps work only in us-east-1 region_**
+**_Pre-requisites: Amazon Web Services (AWS) developer account to launch EC2 instances. AWS CLI installed in terminal and configured with credentials to talk to AWS. All steps work only in us-east-1 region_**
 
 ## AutoScaling Groups with LaunchTemplates
 

--- a/ec2-spot-aws-batch/aws-batch-demo.txt
+++ b/ec2-spot-aws-batch/aws-batch-demo.txt
@@ -1,4 +1,4 @@
-1. Open job defintion and review
+1. Open job definition and review
 
 $ open aws-batch-demo-job-definition.json
 

--- a/ec2-spot-deep-learning-training/README.md
+++ b/ec2-spot-deep-learning-training/README.md
@@ -1,4 +1,4 @@
-# Train Deep Learnng Models on GPUs using Amazon EC2 Spot Instances
+# Train Deep Learning Models on GPUs using Amazon EC2 Spot Instances
 
 This repository contains code and configuration files that accompany the following blog post: **[Train Deep Learning Models on GPUs using Amazon EC2 Spot Instances](https://aws.amazon.com/blogs/machine-learning/train-deep-learning-models-on-gpus-using-ec2-spot-instances/)**
 

--- a/ec2-spot-duration/get_spot_duration.py
+++ b/ec2-spot-duration/get_spot_duration.py
@@ -124,7 +124,7 @@ unix_now = time.time()
 
 sorted_list = list(result.keys())
 sorted_list.sort(key=lambda x: (result.get(x, 0), x))
-print "Duration\tInstance Type\tAvailability Zone"
+print ("Duration\tInstance Type\tAvailability Zone")
 for it in sorted_list:
     date = result.get(it, 0)
-    print "%.1f\t%s\t%s" % ((unix_now - date)/3600.0, it[0], it[1])
+    print ("%.1f\t%s\t%s" % ((unix_now - date)/3600.0, it[0], it[1]))

--- a/ec2-spot-elastic-inference/Readme.MD
+++ b/ec2-spot-elastic-inference/Readme.MD
@@ -34,7 +34,7 @@ Here is a diagram of the resulting architecture:
 To save time on the initial setup, a CloudFormation template will be used to create the Amazon VPC with subnets, as well as various supporting resources including IAM policies and roles, security groups, and a VPC endpoint for you to run the steps for the workshop in.
 
 **To create the stack**
-1.	You can view and download the CloudFormation temlpate from GitHub [here](https://github.com/awslabs/ec2-spot-labs/blob/master/ec2-spot-elastic-inference/EI_Spot_CFN.yaml)
+1.	You can view and download the CloudFormation template from GitHub [here](https://github.com/awslabs/ec2-spot-labs/blob/master/ec2-spot-elastic-inference/EI_Spot_CFN.yaml)
 2.	Take a moment to review the CloudFormation template so you understand the resources it will be creating.
 3.	Browse to the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation).
 Note: Make sure you are in the appropriate AWS Region 
@@ -123,7 +123,7 @@ aws ec2 describe-launch-template-versions  --launch-template-name EI_spot
 
 | Parameter     | Description   |
 | ------------- | ------------- |
-| **LaunchTemplateName**  | Update the LauchTemplateName as “EI_spot” as created above  |
+| **LaunchTemplateName**  | Update the LaunchTemplateName as “EI_spot” as created above  |
 | **%publicSubnet%**  | Update the subnet from the “publicSubnet” of CloudFormation Outputs tab. For example, “subnet-0XXXXXXXXXXX”  |
 | **InstanceType**    | **Optional** - The provided EC2 fleet json has some instance types. Please update the Instance Types as required |
 | **"TotalTargetCapacity": “X”, "OnDemandTargetCapacity": “Y”, "SpotTargetCapacity": “Z”, "DefaultTargetCapacityType": ""**  | **Optional** – The provided EC2 fleet json has some values on TotalTargetCapacity, OnDemandTargetCapacity, SpotTargetCapacity and DefaultTargetCapacityType. According to your compute target capacity, update TotalTargetCapacity, OnDemandTargetCapacity, SpotTargetCapacity and DefaultTargetCapacityType if needed. |

--- a/ec2-spot-interruption-handler/README.md
+++ b/ec2-spot-interruption-handler/README.md
@@ -15,7 +15,7 @@ Optionally, you can also configure a set of commands to be executed on your to-b
 
 You can set up commands you want to execute when your Spot Instances on a specific Auto Scaling group or Spot Fleet are interrupted by creating a parameter within AWS Systems Manager [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) with the commands you want to run. The Lambda function checks if a Parameter exists for the Auto Scaling group that the instance belongs to, if it exists, it will then call RunCommand referencing the parameter, otherwise the function finishes here. With default settings, the parameter name needs to be */spot-instance-interruption-handler/run_commands/\<auto-scaling-group-name\>* or */spot-instance-interruption-handler/run_commands/\<spot-fleet-id\>*.
 
-You can delay the execution of termination commands to x seconds before the Spot instance interruption if, for example, you're allowing time for in-flight http requests to complete before you graceuflly stop your application using the wait_x_seconds_before_interruption.sh bash script (it defaults to 30 seconds before interruption, but you can pass your desired time as parameter. It also requires [jq](https://stedolan.github.io/jq/) installed on the instance). Below you can find an example list of commands that will execute "echo executing termination commands" 60 seconds before the instance is going to be interrupted.
+You can delay the execution of termination commands to x seconds before the Spot instance interruption if, for example, you're allowing time for in-flight http requests to complete before you gracefully stop your application using the wait_x_seconds_before_interruption.sh bash script (it defaults to 30 seconds before interruption, but you can pass your desired time as parameter. It also requires [jq](https://stedolan.github.io/jq/) installed on the instance). Below you can find an example list of commands that will execute "echo executing termination commands" 60 seconds before the instance is going to be interrupted.
 
 ```bash
 curl -s -o /tmp/wait_x_seconds_before_interruption.sh "https://raw.githubusercontent.com/awslabs/ec2-spot-labs/master/ec2-spot-interruption-handler/wait_x_seconds_before_interruption.sh"; chmod u+x /tmp/wait_x_seconds_before_interruption.sh; /tmp/wait_x_seconds_before_interruption.sh 60; echo "executing termination commands"
@@ -33,8 +33,8 @@ The Lambda function execution and the output of your commands is logged on Amazo
 Search for ec2-spot-interruption-handler in the Serverless Application Repository and follow the instructions to deploy. (Make sure you've checked the box labeled: Show apps that create custom IAM roles or resource policies)
 
 If needed, you can modify the following parameters:
- - **SSMParameterPrefix:** The prefix of your Systems Manager Parameters where you will configure the commands youwill run on the different ASGs. This defaults to /spot-instance-interruption-handler/run_commands/. If you leave thedefault settings, your parameters will need to be named */spot-instance-interruption-handler/run_commands/ \<auto-scaling-group-name\>*
- - **EnableRunCommandOutputLogging:** Enable logging to CloudWatch logs of the output of RunCommand (by default is setto *True*, you can disable it setting this to *False*)
+ - **SSMParameterPrefix:** The prefix of your Systems Manager Parameters where you will configure the commands you will run on the different ASGs. This defaults to /spot-instance-interruption-handler/run_commands/. If you leave the default settings, your parameters will need to be named */spot-instance-interruption-handler/run_commands/ \<auto-scaling-group-name\>*
+ - **EnableRunCommandOutputLogging:** Enable logging to CloudWatch logs of the output of RunCommand (by default is set to *True*, you can disable it setting this to *False*)
 
 ### Deployment (Local)
 
@@ -49,7 +49,7 @@ Note: For easiest deployment, create a Cloud9 instance and use the provided envi
 
 #### Deployment Steps
 
-Once you've installed the requirements listed above, open a terminal sesssion as you'll need to run through a few commands to deploy the solution.
+Once you've installed the requirements listed above, open a terminal session as you'll need to run through a few commands to deploy the solution.
 
 Firstly, we need a `S3 bucket` where we can upload our Lambda functions packaged as ZIP before we deploy anything - If you don't have a S3 bucket to store code artifacts then this is a good time to create one:
 
@@ -68,7 +68,7 @@ Next, change directories to the root directory for this example solution.
 cd ec2-spot-labs/ec2-spot-interruption-handler
 ```
 
-Next, run the folllowing command to build the Lambda function:
+Next, run the following command to build the Lambda function:
 
 ```bash
 sam build --use-container
@@ -108,5 +108,5 @@ sam deploy \
 
 - Amazon EventBridge events for AWS service events are free of charge. Pricing details can be found [here](https://aws.amazon.com/eventbridge/pricing/)
 - If you already use all the monthly free tier that AWS Lambda provides, Lambda pricing applies. Otherwise, the usage of this will be covered by the free tier. More info [here](https://aws.amazon.com/lambda/pricing/)
-- AWS Systems Manager Run Command doesn't incurr additional charges (limits apply). Parameter Store has also a Standard tier that doesn't incurr charges. Pricing details can be found [here](https://aws.amazon.com/systems-manager/pricing/)
+- AWS Systems Manager Run Command doesn't incur additional charges (limits apply). Parameter Store has also a Standard tier that doesn't incur charges. Pricing details can be found [here](https://aws.amazon.com/systems-manager/pricing/)
 - AWS Lambda and Run Command log its output to CloudWatch logs. You can find pricing for CloudWatch Logs [here](https://aws.amazon.com/cloudwatch/pricing/)

--- a/ec2-spot-interruption-logging-insights/README.md
+++ b/ec2-spot-interruption-logging-insights/README.md
@@ -2,7 +2,7 @@
 
 This is a sample solution for logging instance details in response to EC2 Spot Instance Interruption Warnings and analyzing them with CloudWatch Log Insights. 
 
-Using CloudWatch Events, an event rule subscribes to EC2 Spot Instance Interruption Warnings, and triggers a Lambda function which collects details about the instance being interrupted and logs that information to a CloudWatch Logs Group. The solution can be configured to log any details you require about your instance, and by default logs InstanceId, InstanceType and all Tags. This information can then be used to develop visualizions with CloudWatch Logs Insights.
+Using CloudWatch Events, an event rule subscribes to EC2 Spot Instance Interruption Warnings, and triggers a Lambda function which collects details about the instance being interrupted and logs that information to a CloudWatch Logs Group. The solution can be configured to log any details you require about your instance, and by default logs InstanceId, InstanceType and all Tags. This information can then be used to develop visualizations with CloudWatch Logs Insights.
 
 ## Overview
 
@@ -95,7 +95,7 @@ Note: For easiest deployment, create a Cloud9 instance and use the provided envi
 
 #### Deployment Steps
 
-Once you've installed the requirements listed above, open a terminal sesssion as you'll need to run through a few commands to deploy the solution.
+Once you've installed the requirements listed above, open a terminal session as you'll need to run through a few commands to deploy the solution.
 
 Firstly, we need a `S3 bucket` where we can upload our Lambda functions packaged as ZIP before we deploy anything - If you don't have a S3 bucket to store code artifacts then this is a good time to create one:
 
@@ -114,7 +114,7 @@ Next, change directories to the root directory for this example solution.
 cd ec2-spot-labs/ec2-spot-interruption-logging-insights
 ```
 
-Next, run the folllowing command to build the Lambda function:
+Next, run the following command to build the Lambda function:
 
 ```bash
 sam build --use-container


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Changing print statement to use built-in function as print statement was removed in Python 3, fixing spelling



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
