### PR TITLE
Updated get_image_uri to sagemaker v2 method

### DIFF
--- a/ec2-spot-sagemaker-managed-spot-training/sagemaker-built-in-xgboost/sagemaker-xgboost.ipynb
+++ b/ec2-spot-sagemaker-managed-spot-training/sagemaker-built-in-xgboost/sagemaker-xgboost.ipynb
@@ -306,8 +306,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(region, 'xgboost')"
+    "from sagemaker.amazon.amazon_estimator import image_uris\n",
+    "container = image_uris.retrieve('xgboost', region, 'latest')"
    ]
   },
   {


### PR DESCRIPTION
I updated the get_image_uri method to the sagemaker v2 method and added the parameter to receive the latest version of xgboost.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
